### PR TITLE
Added function kplotctx_draw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ MANS		= man/kdata_array_alloc.3 \
 		  man/kplot_attach_smooth.3 \
 		  man/kplot_detach.3 \
 		  man/kplot_draw.3 \
+		  man/kplotctx_draw.3 \
 		  man/kplot_free.3 \
 		  man/kplot_get_datacfg.3 \
 		  man/kplot_get_plotcfg.3 \

--- a/draw.c
+++ b/draw.c
@@ -647,90 +647,89 @@ kplotcfg_defaults(struct kplotcfg *cfg)
 }
 
 void
-kplot_draw(struct kplot *p, double w, double h, cairo_t *cr)
+kplotctx_draw(struct kplotctx *ctx, struct kplot *p, double w, double h, cairo_t *cr)
 {
 	size_t	 	 i, start, end;
-	struct kplotctx	 ctx;
 	struct kplotdat	*d;
 	struct kplotccfg defs[7];
 
-	memset(&ctx, 0, sizeof(struct kplotctx));
+	memset(ctx, 0, sizeof(struct kplotctx));
 
-	ctx.w = w;
-	ctx.h = h;
-	ctx.cr = cr;
-	ctx.minv.x = ctx.minv.y = DBL_MAX;
-	ctx.maxv.x = ctx.maxv.y = -DBL_MAX;
-	ctx.cfg = p->cfg;
+	ctx->w = w;
+	ctx->h = h;
+	ctx->cr = cr;
+	ctx->minv.x = ctx->minv.y = DBL_MAX;
+	ctx->maxv.x = ctx->maxv.y = -DBL_MAX;
+	ctx->cfg = p->cfg;
 
-	if (KPLOTCTYPE_DEFAULT == ctx.cfg.borderline.clr.type) {
-		ctx.cfg.borderline.clr.type = KPLOTCTYPE_RGBA;
-		ctx.cfg.borderline.clr.rgba[0] = 0.0;
-		ctx.cfg.borderline.clr.rgba[1] = 0.0;
-		ctx.cfg.borderline.clr.rgba[2] = 0.0;
-		ctx.cfg.borderline.clr.rgba[3] = 1.0;
+	if (KPLOTCTYPE_DEFAULT == ctx->cfg.borderline.clr.type) {
+		ctx->cfg.borderline.clr.type = KPLOTCTYPE_RGBA;
+		ctx->cfg.borderline.clr.rgba[0] = 0.0;
+		ctx->cfg.borderline.clr.rgba[1] = 0.0;
+		ctx->cfg.borderline.clr.rgba[2] = 0.0;
+		ctx->cfg.borderline.clr.rgba[3] = 1.0;
 	}
 
-	if (KPLOTCTYPE_DEFAULT == ctx.cfg.axislabelfont.clr.type) {
-		ctx.cfg.axislabelfont.clr.type = KPLOTCTYPE_RGBA;
-		ctx.cfg.axislabelfont.clr.rgba[0] = 0.0;
-		ctx.cfg.axislabelfont.clr.rgba[1] = 0.0;
-		ctx.cfg.axislabelfont.clr.rgba[2] = 0.0;
-		ctx.cfg.axislabelfont.clr.rgba[3] = 1.0;
+	if (KPLOTCTYPE_DEFAULT == ctx->cfg.axislabelfont.clr.type) {
+		ctx->cfg.axislabelfont.clr.type = KPLOTCTYPE_RGBA;
+		ctx->cfg.axislabelfont.clr.rgba[0] = 0.0;
+		ctx->cfg.axislabelfont.clr.rgba[1] = 0.0;
+		ctx->cfg.axislabelfont.clr.rgba[2] = 0.0;
+		ctx->cfg.axislabelfont.clr.rgba[3] = 1.0;
 	}
 
-	if (KPLOTCTYPE_DEFAULT == ctx.cfg.ticline.clr.type) {
-		ctx.cfg.ticline.clr.type = KPLOTCTYPE_RGBA;
-		ctx.cfg.ticline.clr.rgba[0] = 0.0;
-		ctx.cfg.ticline.clr.rgba[1] = 0.0;
-		ctx.cfg.ticline.clr.rgba[2] = 0.0;
-		ctx.cfg.ticline.clr.rgba[3] = 1.0;
+	if (KPLOTCTYPE_DEFAULT == ctx->cfg.ticline.clr.type) {
+		ctx->cfg.ticline.clr.type = KPLOTCTYPE_RGBA;
+		ctx->cfg.ticline.clr.rgba[0] = 0.0;
+		ctx->cfg.ticline.clr.rgba[1] = 0.0;
+		ctx->cfg.ticline.clr.rgba[2] = 0.0;
+		ctx->cfg.ticline.clr.rgba[3] = 1.0;
 	}
 
-	if (KPLOTCTYPE_DEFAULT == ctx.cfg.gridline.clr.type) {
-		ctx.cfg.gridline.clr.type = KPLOTCTYPE_RGBA;
-		ctx.cfg.gridline.clr.rgba[0] = 0.5;
-		ctx.cfg.gridline.clr.rgba[1] = 0.5;
-		ctx.cfg.gridline.clr.rgba[2] = 0.5;
-		ctx.cfg.gridline.clr.rgba[3] = 1.0;
+	if (KPLOTCTYPE_DEFAULT == ctx->cfg.gridline.clr.type) {
+		ctx->cfg.gridline.clr.type = KPLOTCTYPE_RGBA;
+		ctx->cfg.gridline.clr.rgba[0] = 0.5;
+		ctx->cfg.gridline.clr.rgba[1] = 0.5;
+		ctx->cfg.gridline.clr.rgba[2] = 0.5;
+		ctx->cfg.gridline.clr.rgba[3] = 1.0;
 	}
 
-	if (KPLOTCTYPE_DEFAULT == ctx.cfg.ticlabelfont.clr.type) {
-		ctx.cfg.ticlabelfont.clr.type = KPLOTCTYPE_RGBA;
-		ctx.cfg.ticlabelfont.clr.rgba[0] = 0.5;
-		ctx.cfg.ticlabelfont.clr.rgba[1] = 0.5;
-		ctx.cfg.ticlabelfont.clr.rgba[2] = 0.5;
-		ctx.cfg.ticlabelfont.clr.rgba[3] = 1.0;
+	if (KPLOTCTYPE_DEFAULT == ctx->cfg.ticlabelfont.clr.type) {
+		ctx->cfg.ticlabelfont.clr.type = KPLOTCTYPE_RGBA;
+		ctx->cfg.ticlabelfont.clr.rgba[0] = 0.5;
+		ctx->cfg.ticlabelfont.clr.rgba[1] = 0.5;
+		ctx->cfg.ticlabelfont.clr.rgba[2] = 0.5;
+		ctx->cfg.ticlabelfont.clr.rgba[3] = 1.0;
 	}
 
-	if (0 == ctx.cfg.clrsz) {
-		ctx.cfg.clrs = defs;
-		ctx.cfg.clrsz = 7;
-		for (i = 0; i < ctx.cfg.clrsz; i++) {
-			ctx.cfg.clrs[i].type = KPLOTCTYPE_RGBA;
-			ctx.cfg.clrs[i].rgba[3] = 1.0;
+	if (0 == ctx->cfg.clrsz) {
+		ctx->cfg.clrs = defs;
+		ctx->cfg.clrsz = 7;
+		for (i = 0; i < ctx->cfg.clrsz; i++) {
+			ctx->cfg.clrs[i].type = KPLOTCTYPE_RGBA;
+			ctx->cfg.clrs[i].rgba[3] = 1.0;
 		}
-		ctx.cfg.clrs[0].rgba[0] = 0x94 / 255.0;
-		ctx.cfg.clrs[0].rgba[1] = 0x04 / 255.0;
-		ctx.cfg.clrs[0].rgba[2] = 0xd3 / 255.0;
-		ctx.cfg.clrs[1].rgba[0] = 0x00 / 255.0;
-		ctx.cfg.clrs[1].rgba[1] = 0x9e / 255.0;
-		ctx.cfg.clrs[1].rgba[2] = 0x73 / 255.0;
-		ctx.cfg.clrs[2].rgba[0] = 0x56 / 255.0;
-		ctx.cfg.clrs[2].rgba[1] = 0xb4 / 255.0;
-		ctx.cfg.clrs[2].rgba[2] = 0xe9 / 255.0;
-		ctx.cfg.clrs[3].rgba[0] = 0xe6 / 255.0;
-		ctx.cfg.clrs[3].rgba[1] = 0x9f / 255.0;
-		ctx.cfg.clrs[3].rgba[2] = 0x00 / 255.0;
-		ctx.cfg.clrs[4].rgba[0] = 0xf0 / 255.0;
-		ctx.cfg.clrs[4].rgba[1] = 0xe4 / 255.0;
-		ctx.cfg.clrs[4].rgba[2] = 0x42 / 255.0;
-		ctx.cfg.clrs[5].rgba[0] = 0x00 / 255.0;
-		ctx.cfg.clrs[5].rgba[1] = 0x72 / 255.0;
-		ctx.cfg.clrs[5].rgba[2] = 0xb2 / 255.0;
-		ctx.cfg.clrs[6].rgba[0] = 0xe5 / 255.0;
-		ctx.cfg.clrs[6].rgba[1] = 0x1e / 255.0;
-		ctx.cfg.clrs[6].rgba[2] = 0x10 / 255.0;
+		ctx->cfg.clrs[0].rgba[0] = 0x94 / 255.0;
+		ctx->cfg.clrs[0].rgba[1] = 0x04 / 255.0;
+		ctx->cfg.clrs[0].rgba[2] = 0xd3 / 255.0;
+		ctx->cfg.clrs[1].rgba[0] = 0x00 / 255.0;
+		ctx->cfg.clrs[1].rgba[1] = 0x9e / 255.0;
+		ctx->cfg.clrs[1].rgba[2] = 0x73 / 255.0;
+		ctx->cfg.clrs[2].rgba[0] = 0x56 / 255.0;
+		ctx->cfg.clrs[2].rgba[1] = 0xb4 / 255.0;
+		ctx->cfg.clrs[2].rgba[2] = 0xe9 / 255.0;
+		ctx->cfg.clrs[3].rgba[0] = 0xe6 / 255.0;
+		ctx->cfg.clrs[3].rgba[1] = 0x9f / 255.0;
+		ctx->cfg.clrs[3].rgba[2] = 0x00 / 255.0;
+		ctx->cfg.clrs[4].rgba[0] = 0xf0 / 255.0;
+		ctx->cfg.clrs[4].rgba[1] = 0xe4 / 255.0;
+		ctx->cfg.clrs[4].rgba[2] = 0x42 / 255.0;
+		ctx->cfg.clrs[5].rgba[0] = 0x00 / 255.0;
+		ctx->cfg.clrs[5].rgba[1] = 0x72 / 255.0;
+		ctx->cfg.clrs[5].rgba[2] = 0xb2 / 255.0;
+		ctx->cfg.clrs[6].rgba[0] = 0xe5 / 255.0;
+		ctx->cfg.clrs[6].rgba[1] = 0x1e / 255.0;
+		ctx->cfg.clrs[6].rgba[2] = 0x10 / 255.0;
 	} 
 
 	for (i = 0; i < p->datasz; i++) {
@@ -738,36 +737,36 @@ kplot_draw(struct kplot *p, double w, double h, cairo_t *cr)
 		switch (d->stype) {
 		case (KPLOTS_YERRORBAR):
 		case (KPLOTS_YERRORLINE):
-			kdata_extrema_yerr(d, &ctx);
+			kdata_extrema_yerr(d, ctx);
 			break;
 		case (KPLOTS_SINGLE):
-			kdata_extrema_single(d, &ctx);
+			kdata_extrema_single(d, ctx);
 			break;
 		}
 	}
 
-	if (EXTREMA_XMIN & ctx.cfg.extrema)
-		ctx.minv.x = ctx.cfg.extrema_xmin;
-	if (EXTREMA_YMIN & ctx.cfg.extrema)
-		ctx.minv.y = ctx.cfg.extrema_ymin;
-	if (EXTREMA_XMAX & ctx.cfg.extrema)
-		ctx.maxv.x = ctx.cfg.extrema_xmax;
-	if (EXTREMA_YMAX & ctx.cfg.extrema)
-		ctx.maxv.y = ctx.cfg.extrema_ymax;
+	if (EXTREMA_XMIN & ctx->cfg.extrema)
+		ctx->minv.x = ctx->cfg.extrema_xmin;
+	if (EXTREMA_YMIN & ctx->cfg.extrema)
+		ctx->minv.y = ctx->cfg.extrema_ymin;
+	if (EXTREMA_XMAX & ctx->cfg.extrema)
+		ctx->maxv.x = ctx->cfg.extrema_xmax;
+	if (EXTREMA_YMAX & ctx->cfg.extrema)
+		ctx->maxv.y = ctx->cfg.extrema_ymax;
 
-	if (ctx.minv.x > ctx.maxv.x)
-		ctx.minv.x = ctx.maxv.x = 0.0;
-	if (ctx.minv.y > ctx.maxv.y)
-		ctx.minv.y = ctx.maxv.y = 0.0;
+	if (ctx->minv.x > ctx->maxv.x)
+		ctx->minv.x = ctx->maxv.x = 0.0;
+	if (ctx->minv.y > ctx->maxv.y)
+		ctx->minv.y = ctx->maxv.y = 0.0;
 
-	kplotctx_margin_init(&ctx);
-	kplotctx_label_init(&ctx);
-	kplotctx_grid_init(&ctx);
-	kplotctx_border_init(&ctx);
-	kplotctx_tic_init(&ctx);
+	kplotctx_margin_init(ctx);
+	kplotctx_label_init(ctx);
+	kplotctx_grid_init(ctx);
+	kplotctx_border_init(ctx);
+	kplotctx_tic_init(ctx);
 	
-	ctx.h = ctx.dims.y;
-	ctx.w = ctx.dims.x;
+	ctx->h = ctx->dims.y;
+	ctx->w = ctx->dims.x;
 
 	for (i = 0; i < p->datasz; i++) {
 		d = &p->datas[i];
@@ -775,21 +774,21 @@ kplot_draw(struct kplot *p, double w, double h, cairo_t *cr)
 		case (KPLOTS_SINGLE):
 			switch (d->types[0]) {
 			case (KPLOT_POINTS):
-				kplotctx_draw_points(&ctx, d);
+				kplotctx_draw_points(ctx, d);
 				break;
 			case (KPLOT_MARKS):
-				kplotctx_draw_marks(&ctx, d);
+				kplotctx_draw_marks(ctx, d);
 				break;
 			case (KPLOT_LINES):
-				kplotctx_draw_lines(&ctx, d);
+				kplotctx_draw_lines(ctx, d);
 				break;
 			case (KPLOT_LINESPOINTS):
-				kplotctx_draw_points(&ctx, d);
-				kplotctx_draw_lines(&ctx, d);
+				kplotctx_draw_points(ctx, d);
+				kplotctx_draw_lines(ctx, d);
 				break;
 			case (KPLOT_LINESMARKS):
-				kplotctx_draw_marks(&ctx, d);
-				kplotctx_draw_lines(&ctx, d);
+				kplotctx_draw_marks(ctx, d);
+				kplotctx_draw_lines(ctx, d);
 				break;
 			default:
 				abort();
@@ -799,34 +798,34 @@ kplot_draw(struct kplot *p, double w, double h, cairo_t *cr)
 		case (KPLOTS_YERRORBAR):
 		case (KPLOTS_YERRORLINE):
 			start = kplotctx_draw_yerrline_start
-				(&ctx, d, &end);
+				(ctx, d, &end);
 			if (start == end)
 				break;
 			assert(d->datasz > 1);
 			switch (d->types[0]) {
 			case (KPLOT_POINTS):
 				kplotctx_draw_yerrline_basepoints
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				break;
 			case (KPLOT_MARKS):
 				kplotctx_draw_yerrline_basemarks
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				break;
 			case (KPLOT_LINES):
 				kplotctx_draw_yerrline_baselines
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				break;
 			case (KPLOT_LINESPOINTS):
 				kplotctx_draw_yerrline_basepoints
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				kplotctx_draw_yerrline_baselines
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				break;
 			case (KPLOT_LINESMARKS):
 				kplotctx_draw_yerrline_basemarks
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				kplotctx_draw_yerrline_baselines
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				break;
 			default:
 				abort();
@@ -835,27 +834,27 @@ kplot_draw(struct kplot *p, double w, double h, cairo_t *cr)
 			switch (p->datas[i].types[1]) {
 			case (KPLOT_POINTS):
 				kplotctx_draw_yerrline_pairpoints
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				break;
 			case (KPLOT_MARKS):
 				kplotctx_draw_yerrline_pairmarks
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				break;
 			case (KPLOT_LINES):
 				kplotctx_draw_yerrline_pairlines
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				break;
 			case (KPLOT_LINESPOINTS):
 				kplotctx_draw_yerrline_pairpoints
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				kplotctx_draw_yerrline_pairlines
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				break;
 			case (KPLOT_LINESMARKS):
 				kplotctx_draw_yerrline_pairmarks
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				kplotctx_draw_yerrline_pairlines
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 				break;
 			default:
 				abort();
@@ -863,7 +862,7 @@ kplot_draw(struct kplot *p, double w, double h, cairo_t *cr)
 			}
 			if (KPLOTS_YERRORBAR == d->stype)
 				kplotctx_draw_yerrline_pairbars
-					(&ctx, start, end, d);
+					(ctx, start, end, d);
 			break;
 		default:
 			break;
@@ -871,6 +870,12 @@ kplot_draw(struct kplot *p, double w, double h, cairo_t *cr)
 	}
 }
 
+void
+kplot_draw(struct kplot *p, double w, double h, cairo_t *cr)
+{
+	struct kplotctx	ctx;
+	kplotctx_draw(&ctx, p, w, h, cr);
+}
 int
 kplotcfg_default_palette(struct kplotccfg **pp, size_t *szp)
 {

--- a/extern.h
+++ b/extern.h
@@ -101,25 +101,6 @@ struct	kplot {
 	struct kplotcfg	 cfg; /* configuration */
 };
 
-struct	kplotctx {
-	cairo_t		*cr; /* cairo context */
-	double		 h; /* height of context */
-	double		 w; /* width of context */
-	struct kpair	 minv; /* minimum data point values */
-	struct kpair	 maxv; /* maximum data point values */
-	struct kplotcfg	 cfg;
-
-	/*
-	 * When computing the plot context, we need to account for a
-	 * margin, labels, and boundary.
-	 * To do this, we use these "soft" offset and dimensions.
-	 * Once we've accounted for the above, we'll use this to
-	 * translate and resize the Cairo context for graphing.
-	 */
-	struct kpair	 offs;
-	struct kpair	 dims;
-};
-
 __BEGIN_DECLS
 
 int	 kdata_dep_add(struct kdata *, struct kdata *, ksetfunc);

--- a/kplot.h
+++ b/kplot.h
@@ -170,6 +170,7 @@ struct	kplotcfg {
 
 struct 	kdata;
 struct	kplot;
+struct	kplotctx;
 
 __BEGIN_DECLS
 
@@ -234,6 +235,7 @@ int		 kplot_attach_smooth(struct kplot *, struct kdata *,
 int		 kplot_attach_datas(struct kplot *, size_t, 
 			struct kdata **, const enum kplottype *, 
 			const struct kdatacfg *const *, enum kplotstype);
+void		 kplotctx_draw(struct kplotctx *, struct kplot *, double, double, cairo_t *);
 void		 kplot_draw(struct kplot *, double, double, cairo_t *);
 void		 kplot_free(struct kplot *);
 int		 kplot_get_datacfg(struct kplot *, size_t,

--- a/kplot.h
+++ b/kplot.h
@@ -168,9 +168,28 @@ struct	kplotcfg {
 	double		  extrema_ymax;
 };
 
+struct  kplotctx {
+    cairo_t     *cr; /* cairo context */
+    double       h; /* height of context */
+    double       w; /* width of context */
+    struct kpair     minv; /* minimum data point values */
+    struct kpair     maxv; /* maximum data point values */
+    struct kplotcfg  cfg;
+
+    /*
+     * When computing the plot context, we need to account for a
+     * margin, labels, and boundary.
+     * To do this, we use these "soft" offset and dimensions.
+     * Once we've accounted for the above, we'll use this to
+     * translate and resize the Cairo context for graphing.
+     */
+    struct kpair     offs;
+    struct kpair     dims;
+};
+
+
 struct 	kdata;
 struct	kplot;
-struct	kplotctx;
 
 __BEGIN_DECLS
 

--- a/man/kplot.3
+++ b/man/kplot.3
@@ -47,6 +47,8 @@ by multiple plots.
 .It
 Draw plots to Cairo contexts with
 .Xr kplot_draw 3 .
+or
+.Xr kplotctx_draw 3 .
 .It
 Free plots with
 .Xr kplot_free 3
@@ -57,6 +59,8 @@ and data sources with
 Each plot domain and range is extended to fit all of its data sources at
 the moment
 .Xr kplot_draw 3
+or
+.Xr kplotctx_draw 3 .
 is invoked.
 .Ss Styles
 Styles are applied to plots and when a plot data source is added to a
@@ -179,6 +183,7 @@ functions are also provided.
 .Xr kplot_attach_smooth 3 ,
 .Xr kplot_detach 3 ,
 .Xr kplot_draw 3 ,
+.Xr kplotctx_draw 3 ,
 .Xr kplot_free 3 ,
 .Xr kplot_get_datacfg 3 ,
 .Xr kplot_get_plotcfg 3 ,

--- a/man/kplotctx_draw.3
+++ b/man/kplotctx_draw.3
@@ -2,7 +2,7 @@
 .Dt KPLOT_DRAW 3
 .Os
 .Sh NAME
-.Nm kplot_draw
+.Nm kplotctx_draw
 .Nd plot data on Cairo context
 .Sh LIBRARY
 .Lb libkplot
@@ -10,7 +10,8 @@
 .In cairo.h
 .In kplot.h
 .Ft void
-.Fo kplot_draw
+.Fo kplotctx_draw
+.Fa "struct kplotctx *ctx"
 .Fa "const struct kplot *p"
 .Fa double w
 .Fa double h
@@ -19,7 +20,15 @@
 .Sh DESCRIPTION
 The
 .Nm
-function draws all valid points of all data sources onto a Cairo context
+function is equivalent to 
+.Xr kplot_draw 3
+with the only difference, that the plot context is returned into
+.Fa ctx .
+User is responsible for allocatinf sufficient memory.q
+.Nm
+draws all valid points of all data sources attached to
+.Fa p
+onto a Cairo context
 .Fa cr
 of height
 .Fa h
@@ -43,7 +52,7 @@ The image is laid out as described in the Drawing Model section of
 .\" For sections 2, 3, 4, and 9 errno settings only.
 .Sh SEE ALSO
 .Xr kplot 3 ,
-.Xr kplotctx_draw 3 ,
+.Xr kplot_draw 3 ,
 .Xr kplot_alloc 3
 .\" .Sh STANDARDS
 .\" .Sh HISTORY


### PR DESCRIPTION
Added function kplotctx_draw is functionally equivalent to kplot_draw but returns the plot context as a strcut kplotctx. This is useful for everyone who needs to translate plot coordinates to coordinates in the cairo context and vice versa. 